### PR TITLE
fixed non-linux build by ignoring integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,6 @@ libc = "0.2.0"
 slog-term = "2.5.0"
 slog-async = "2.4.0"
 sloggers = "0.3.5"
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
 iptables = "0.2.2"

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")] // namespaces, iptables: all these is linux-specicfic.
 use anyhow;
 use membership;
 use membership::Node;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")] // namespaces, iptables: all these is linux-specicfic.
 use iptables;
 use membership::{Node, ProtocolConfig};
 use sloggers::terminal::TerminalLoggerBuilder;


### PR DESCRIPTION
This commit fixes following issue:

error[E0599]: no method named `exists` found for reference `&IPTables` in the current scope
   --> /Users/serejkus/.cargo/registry/src/github.com-1ecc6299db9ec823/iptables-0.2.2/src/lib.rs:195:17
    |
195 |         if self.exists(table, chain, rule)? {
    |                 ^^^^^^ method not found in `&IPTables`

The problem is that integration tests are Linux-specific: they rely on
iptables and network namespaces. It complicates development on non-Linux
platforms.